### PR TITLE
[FixBug] Fixed bug when attribute is actually an "0"

### DIFF
--- a/src/Helper/XmlHelper.php
+++ b/src/Helper/XmlHelper.php
@@ -51,14 +51,12 @@ class XmlHelper
 	 */
 	public static function getAttribute(\SimpleXMLElement $xml, $attr, $default = null)
 	{
-		$value = (string) $xml[$attr];
-
-		if (!$value)
+		if (!isset($xml[$attr]))
 		{
 			return $default;
 		}
 
-		return $value;
+		return (string) $xml[$attr];
 	}
 
 	/**


### PR DESCRIPTION
When we set an attribute in XML file like this: "some_value"="0"
(The value with this attribute accept any integer include "0")
Then, we use XmlHelper to get the value with: "$value = XMLHelper::get($element, 'some_value', 3);"
The value will be "3" instead of "0"

These changes could fix this kind of problem
