### PR TITLE
[fix] override JoomlaContainer::getRaw to avoid bug in joomla-framework

### DIFF
--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -15,7 +15,7 @@ use Joomla\DI\Container as JoomlaContainer;
  *
  * Based on Joomla DI Container.
  *
- * @since 2.0
+ * @since  2.0
  */
 class Container extends JoomlaContainer
 {
@@ -43,7 +43,7 @@ class Container extends JoomlaContainer
 	/**
 	 * Get the container instance by name.
 	 *
-	 * @param string $name Container name, if is null, get the main container.
+	 * @param   string  $name  Container name, if is null, get the main container.
 	 *
 	 * @return Container
 	 */
@@ -144,17 +144,24 @@ class Container extends JoomlaContainer
 	 * @param   string  $key  The key for which to get the stored item.
 	 *
 	 * @return  mixed
+	 *
+	 * @since   2.0.11
 	 */
 	protected function getRaw($key)
 	{
-		$key = $this->resolveAlias($key);
-
 		if (isset($this->dataStore[$key]))
 		{
 			return $this->dataStore[$key];
 		}
 
-		if ($this->parent instanceof Container)
+		$aliasKey = $this->resolveAlias($key);
+
+		if ($aliasKey != $key && isset($this->dataStore[$aliasKey]))
+		{
+			return $this->dataStore[$aliasKey];
+		}
+
+		if ($this->parent instanceof JoomlaContainer)
 		{
 			return $this->parent->getRaw($key);
 		}

--- a/src/DI/Container.php
+++ b/src/DI/Container.php
@@ -116,9 +116,8 @@ class Container extends JoomlaContainer
 	 */
 	public function get($key, $forceNew = false)
 	{
-		$raw = $this->getRaw($key);
-
 		$key = $this->resolveAlias($key);
+		$raw = $this->getRaw($key);
 
 		if (is_null($raw))
 		{
@@ -136,6 +135,31 @@ class Container extends JoomlaContainer
 		}
 
 		return call_user_func($raw['callback'], $this);
+	}
+
+	/**
+	 * Get the raw data assigned to a key.
+	 * Override to prevent joomla-framework bug not resolving parent aliases
+	 *
+	 * @param   string  $key  The key for which to get the stored item.
+	 *
+	 * @return  mixed
+	 */
+	protected function getRaw($key)
+	{
+		$key = $this->resolveAlias($key);
+
+		if (isset($this->dataStore[$key]))
+		{
+			return $this->dataStore[$key];
+		}
+
+		if ($this->parent instanceof Container)
+		{
+			return $this->parent->getRaw($key);
+		}
+
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
This fixes the issue https://github.com/asikart/quickicons/issues/26 caused because in the framework the `resolveAlias()` method was removed from `getRaw()` (see https://github.com/joomla-framework/di/commit/73cc4e1d26ebd7aa8a0a2eea52031b2b42dab22a#diff-5772c249f61507a501a28c2087d7d2a8L384 ) so parent containers never resolve aliases.

Until framework is fixed I think is ok to override the method to have it working properly.